### PR TITLE
Refactor docker package using Project struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,20 @@ import (
 )
 
 func TestItMyFriend(t *testing.T) {
-    container, err := docker.Start("vdemeester/myawesomeimage")
+    project, err := docker.NewProjectFromEnv()
+    if err != nil {
+        t.Fatal(err)
+    }
+    container, err := p.Start("vdemeester/myawesomeimage")
     if err != nil {
         t.Fatal(err)
     }
 
     // Do your stuff
+    // […]
 
-    err = docker.Stop(container.ID)
+    // Clean the containers managed by libkermit
+    err = docker.Clean()
     if err != nil {
         t.Fatal(err)
     }

--- a/docker/clean.go
+++ b/docker/clean.go
@@ -1,29 +1,17 @@
 package docker
 
-import (
-	"github.com/docker/engine-api/client"
-)
-
 // Clean stops and removes (by default, controllable with the keep) kermit containers
-func Clean(keep bool) error {
-	client, err := client.NewEnvClient()
-	if err != nil {
-		return err
-	}
-	return clean(client, keep)
-}
-
-func clean(client client.APIClient, keep bool) error {
-	containers, err := list(client)
+func (p *Project) Clean(keep bool) error {
+	containers, err := p.List()
 	if err != nil {
 		return err
 	}
 	for _, container := range containers {
-		if err := stopWithTimeout(client, container.ID, 1); err != nil {
+		if err := p.StopWithTimeout(container.ID, 1); err != nil {
 			return err
 		}
 		if !keep {
-			if err := remove(client, container.ID); err != nil {
+			if err := p.Remove(container.ID); err != nil {
 				return err
 			}
 		}

--- a/docker/image.go
+++ b/docker/image.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/engine-api/types"
 )
 
-func ensureImageExists(cli client.APIClient, image string) error {
+func (p *Project) ensureImageExists(image string) error {
 	distributionRef, err := reference.ParseNamed(image)
 	if err != nil {
 		return err
@@ -28,7 +28,7 @@ func ensureImageExists(cli client.APIClient, image string) error {
 	}
 
 	// Check if image is already there
-	_, _, err = cli.ImageInspectWithRaw(context.Background(), image, false)
+	_, _, err = p.Client.ImageInspectWithRaw(context.Background(), image, false)
 	if err != nil && !client.IsErrImageNotFound(err) {
 		return err
 	}
@@ -41,7 +41,7 @@ func ensureImageExists(cli client.APIClient, image string) error {
 		ImageID: distributionRef.Name(),
 		Tag:     tag,
 	}
-	responseBody, err := cli.ImagePull(context.Background(), options, nil)
+	responseBody, err := p.Client.ImagePull(context.Background(), options, nil)
 	if err != nil {
 		fmt.Printf("%v", err)
 		return err

--- a/docker/inspect.go
+++ b/docker/inspect.go
@@ -3,21 +3,12 @@ package docker
 import (
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 )
 
 // Inspect returns the container informations
-func Inspect(containerID string) (types.ContainerJSON, error) {
-	client, err := client.NewEnvClient()
-	if err != nil {
-		return types.ContainerJSON{}, err
-	}
-	return inspect(client, containerID)
-}
-
-func inspect(client client.APIClient, containerID string) (types.ContainerJSON, error) {
-	container, err := client.ContainerInspect(context.Background(), containerID)
+func (p *Project) Inspect(containerID string) (types.ContainerJSON, error) {
+	container, err := p.Client.ContainerInspect(context.Background(), containerID)
 	if err != nil {
 		return types.ContainerJSON{}, err
 	}

--- a/docker/list.go
+++ b/docker/list.go
@@ -3,24 +3,17 @@ package docker
 import (
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
 )
 
 // List lists the containers managed by kermit
-func List() ([]types.Container, error) {
-	client, err := client.NewEnvClient()
-	if err != nil {
-		return nil, err
-	}
-	return list(client)
-}
-
-func list(client client.APIClient) ([]types.Container, error) {
+func (p *Project) List() ([]types.Container, error) {
 	filters := filters.NewArgs()
-	filters.Add(KermitLabel, "true")
-	containers, err := client.ContainerList(context.Background(), types.ContainerListOptions{
+	for key, value := range p.Labels {
+		filters.Add(key, value)
+	}
+	containers, err := p.Client.ContainerList(context.Background(), types.ContainerListOptions{
 		Filter: filters,
 	})
 	if err != nil {

--- a/docker/project.go
+++ b/docker/project.go
@@ -1,0 +1,29 @@
+package docker
+
+import (
+	"github.com/docker/engine-api/client"
+)
+
+// Project holds docker related project attributes, like docker client, labels
+// to put on the containers, and so on.
+type Project struct {
+	Client client.APIClient
+	Labels map[string]string
+}
+
+// NewProjectFromEnv creates a project with a client that is build from environment variables.
+func NewProjectFromEnv() (*Project, error) {
+	client, err := client.NewEnvClient()
+	if err != nil {
+		return nil, err
+	}
+	return NewProject(client), nil
+}
+
+// NewProject creates a project with the given client and the default attributes.
+func NewProject(client client.APIClient) *Project {
+	return &Project{
+		Client: client,
+		Labels: KermitLabels,
+	}
+}

--- a/docker/remove.go
+++ b/docker/remove.go
@@ -3,21 +3,12 @@ package docker
 import (
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 )
 
 // Remove removes the container
-func Remove(containerID string) error {
-	client, err := client.NewEnvClient()
-	if err != nil {
-		return err
-	}
-	return remove(client, containerID)
-}
-
-func remove(cli client.APIClient, containerID string) error {
-	if err := cli.ContainerRemove(context.Background(), types.ContainerRemoveOptions{
+func (p *Project) Remove(containerID string) error {
+	if err := p.Client.ContainerRemove(context.Background(), types.ContainerRemoveOptions{
 		ContainerID: containerID,
 		Force:       true,
 	}); err != nil {

--- a/docker/start.go
+++ b/docker/start.go
@@ -3,41 +3,26 @@ package docker
 import (
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 )
 
 // Start lets you create and start a container with the specified image, and
 // default configuration.
-func Start(image string) (types.ContainerJSON, error) {
-	client, err := client.NewEnvClient()
-	if err != nil {
-		return types.ContainerJSON{}, err
-	}
-
-	return start(client, image, ContainerConfig{})
+func (p *Project) Start(image string) (types.ContainerJSON, error) {
+	return p.StartWithConfig(image, ContainerConfig{})
 }
 
 // StartWithConfig lets you create and start a container with the specified
 // image, and some custom simple configuration.
-func StartWithConfig(image string, config ContainerConfig) (types.ContainerJSON, error) {
-	client, err := client.NewEnvClient()
+func (p *Project) StartWithConfig(image string, containerConfig ContainerConfig) (types.ContainerJSON, error) {
+	container, err := p.CreateWithConfig(image, containerConfig)
 	if err != nil {
 		return types.ContainerJSON{}, err
 	}
 
-	return start(client, image, config)
-}
-
-func start(client client.APIClient, image string, containerConfig ContainerConfig) (types.ContainerJSON, error) {
-	container, err := create(client, image, containerConfig)
-	if err != nil {
-		return types.ContainerJSON{}, err
-	}
-
-	if err := client.ContainerStart(context.Background(), container.ID); err != nil {
+	if err := p.Client.ContainerStart(context.Background(), container.ID); err != nil {
 		return container, err
 	}
 
-	return inspect(client, container.ID)
+	return p.Inspect(container.ID)
 }

--- a/docker/status.go
+++ b/docker/status.go
@@ -1,38 +1,22 @@
 package docker
 
-import (
-	"github.com/docker/engine-api/client"
-)
-
 // IsRunning checks if the container is running or not
-func IsRunning(containerID string) (bool, error) {
-	client, err := client.NewEnvClient()
-	if err != nil {
-		return false, nil
-	}
-	return containerStatus(client, containerID, "running")
+func (p *Project) IsRunning(containerID string) (bool, error) {
+	return p.containerStatus(containerID, "running")
 }
 
 // IsStopped checks if the container is running or not
-func IsStopped(containerID string) (bool, error) {
-	client, err := client.NewEnvClient()
-	if err != nil {
-		return false, nil
-	}
-	return containerStatus(client, containerID, "stopped")
+func (p *Project) IsStopped(containerID string) (bool, error) {
+	return p.containerStatus(containerID, "stopped")
 }
 
 // IsPaused checks if the container is running or not
-func IsPaused(containerID string) (bool, error) {
-	client, err := client.NewEnvClient()
-	if err != nil {
-		return false, nil
-	}
-	return containerStatus(client, containerID, "paused")
+func (p *Project) IsPaused(containerID string) (bool, error) {
+	return p.containerStatus(containerID, "paused")
 }
 
-func containerStatus(client client.APIClient, containerID, status string) (bool, error) {
-	containerJSON, err := inspect(client, containerID)
+func (p *Project) containerStatus(containerID, status string) (bool, error) {
+	containerJSON, err := p.Inspect(containerID)
 	if err != nil {
 		return false, err
 	}

--- a/docker/stop.go
+++ b/docker/stop.go
@@ -2,26 +2,16 @@ package docker
 
 import (
 	"golang.org/x/net/context"
-
-	"github.com/docker/engine-api/client"
 )
 
 // Stop stops the container with a default timeout.
-func Stop(containerID string) error {
-	return StopWithTimeout(containerID, DefaultStopTimeout)
+func (p *Project) Stop(containerID string) error {
+	return p.StopWithTimeout(containerID, DefaultStopTimeout)
 }
 
 // StopWithTimeout stops the container with the specified timeout.
-func StopWithTimeout(containerID string, timeout int) error {
-	client, err := client.NewEnvClient()
-	if err != nil {
-		return err
-	}
-	return stopWithTimeout(client, containerID, timeout)
-}
-
-func stopWithTimeout(client client.APIClient, containerID string, timeout int) error {
-	if err := client.ContainerStop(context.Background(), containerID, timeout); err != nil {
+func (p *Project) StopWithTimeout(containerID string, timeout int) error {
+	if err := p.Client.ContainerStop(context.Background(), containerID, timeout); err != nil {
 		return err
 	}
 

--- a/integration/docker/helper_test.go
+++ b/integration/docker/helper_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/vdemeester/libkermit/docker"
 )
 
-func setupTest(t *testing.T) {
-	cleanContainers(t)
+func setupTest(t *testing.T) *docker.Project {
+	return cleanContainers(t)
 }
 
-func cleanContainers(t *testing.T) {
+func cleanContainers(t *testing.T) *docker.Project {
 	client, err := dockerclient.NewEnvClient()
 	if err != nil {
 		t.Fatal(err)
@@ -44,4 +44,6 @@ func cleanContainers(t *testing.T) {
 			t.Errorf("Error while removing container %s : %v\n", container.ID, err)
 		}
 	}
+
+	return docker.NewProject(client)
 }

--- a/integration/docker/simple_test.go
+++ b/integration/docker/simple_test.go
@@ -3,14 +3,12 @@ package dockerit
 import (
 	"strings"
 	"testing"
-
-	"github.com/vdemeester/libkermit/docker"
 )
 
 func TestCreateSimple(t *testing.T) {
-	setupTest(t)
+	project := setupTest(t)
 
-	container, err := docker.Create("busybox")
+	container, err := project.Create("busybox")
 
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -24,9 +22,9 @@ func TestCreateSimple(t *testing.T) {
 }
 
 func TestStartAndStop(t *testing.T) {
-	setupTest(t)
+	project := setupTest(t)
 
-	container, err := docker.Start("busybox")
+	container, err := project.Start("busybox")
 
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -41,12 +39,12 @@ func TestStartAndStop(t *testing.T) {
 		t.Fatalf("expected container to be running, but was in state %v", container.State)
 	}
 
-	err = docker.Stop(container.ID)
+	err = project.Stop(container.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	container, err = docker.Inspect(container.ID)
+	container, err = project.Inspect(container.ID)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}


### PR DESCRIPTION
To ease the use of the `docker` package, this introduce a `Project` struct where you can share client and kermit labels for now. Then you can use the struct to manage containers 🐳.

    project := docker.NewProject(client)
    project.Start("containous/traefik")
    // Do your stuff […]
    project.Clean()

🐸