### PR TITLE
Add support to test against multiple daemon version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
 
 script:
   - make validate
-  - make test
+  - make DAEMON_VERSION="all" test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.6.1
 
 RUN apt-get update && apt-get install -y \
-    build-essential \
+    iptables build-essential \
     --no-install-recommends
 
 # Install build dependencies
@@ -9,21 +9,35 @@ RUN go get golang.org/x/tools/cmd/cover \
     && go get github.com/golang/lint/golint \
     && go get github.com/Masterminds/glide 
 
-# Which docker version to test on
-ENV DOCKER_VERSION 1.10.3
-
-# enable GO15VENDOREXPERIMENT
-ENV GO15VENDOREXPERIMENT 1
+# Which docker version to test on and what default one to use
+ENV DOCKER_VERSIONS 1.10.3 1.11.0
+ENV DEFAULT_DOCKER_VERSION 1.10.3
 
 # Download docker
-RUN set -ex; \
-    curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} -o /usr/local/bin/docker; \
-    chmod +x /usr/local/bin/docker
+RUN set -e; \
+    for v in $(echo ${DOCKER_VERSIONS} | cut -f1); do \
+        if test "${v}" = "1.9.1" || test "${v}" = "1.10.3"; then \
+           mkdir -p /usr/local/bin/docker-${v}/; \
+           curl https://get.docker.com/builds/Linux/x86_64/docker-${v} -o /usr/local/bin/docker-${v}/docker; \
+           chmod +x /usr/local/bin/docker-${v}/docker; \
+        else \
+             curl https://get.docker.com/builds/Linux/x86_64/docker-${v}.tgz -o docker-${v}.tgz; \
+             tar xzf docker-${v}.tgz -C /usr/local/bin/; \
+             mv /usr/local/bin/docker /usr/local/bin/docker-${v}; \
+             rm docker-${v}.tgz; \
+        fi \
+    done
+
+# Set the default Docker to be run
+RUN ln -s /usr/local/bin/docker-${DEFAULT_DOCKER_VERSION} /usr/local/bin/docker
     
 WORKDIR /go/src/github.com/vdemeester/libkermit
 
 COPY glide.yaml glide.yaml
 COPY glide.lock glide.lock
 RUN glide install
+
+# Wrap all commands in the "docker-in-docker" script to allow nested containers
+ENTRYPOINT ["hack/dind"]
 
 COPY . /go/src/github.com/vdemeester/libkermit

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
 
-LIBCOMPOSE_ENVS := \
+LIBKERMIT_ENVS := \
 	-e DOCKER_TEST_HOST \
 	-e TESTFLAGS
 
@@ -10,9 +10,9 @@ LIBKERMIT_MOUNT := -v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/vdemeester/libke
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 LIBKERMIT_DEV_IMAGE := libkermit-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 REPONAME := $(shell echo $(REPO) | tr '[:upper:]' '[:lower:]')
-INTEGRATION_OPTS := $(if $(MAKE_DOCKER_HOST),-e "DOCKER_HOST=$(MAKE_DOCKER_HOST)", -v "/var/run/docker.sock:/var/run/docker.sock")
 
-DOCKER_RUN_LIBKERMIT := docker run $(if $(CIRCLECI),,--rm) $(INTEGRATION_OPTS) -it $(LIBKERMIT_ENVS) $(LIBKERMIT_MOUNT) "$(LIBKERMIT_DEV_IMAGE)"
+DAEMON_VERSION := $(if $(DAEMON_VERSION),$(DAEMON_VERSION),"default")
+DOCKER_RUN_LIBKERMIT := docker run --rm --privileged -it -e DAEMON_VERSION="$(DAEMON_VERSION)" $(LIBKERMIT_ENVS) $(LIBKERMIT_MOUNT) "$(LIBKERMIT_DEV_IMAGE)"
 
 default: all
 

--- a/glide.lock
+++ b/glide.lock
@@ -66,7 +66,7 @@ imports:
   - pkg/ulimit
   - volume
 - name: github.com/docker/engine-api
-  version: a6dca654f28f26b648115649f6382252ada81119
+  version: a2999dbd3471ffe167f2aec7dccb9fa9b016dcbc
   subpackages:
   - client
   - types

--- a/hack/.integration-daemon-start
+++ b/hack/.integration-daemon-start
@@ -1,0 +1,65 @@
+#!/bin/bash
+# see test-integration-cli for example usage of this script
+
+export PATH="/usr/local/bin/docker-${DOCKER_DAEMON_VERSION}:$PATH"
+
+if ! command -v docker &> /dev/null; then
+    echo >&2 'error: docker binary should be present to be able to run test-integration'
+    false
+fi
+
+# intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
+exec 41>&1 42>&2
+
+export DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
+export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
+
+# example usage: DOCKER_STORAGE_OPTS="dm.basesize=20G,dm.loopdatasize=200G"
+storage_params=""
+if [ -n "$DOCKER_STORAGE_OPTS" ]; then
+    IFS=','
+    for i in ${DOCKER_STORAGE_OPTS}; do
+        storage_params="--storage-opt $i $storage_params"
+    done
+    unset IFS
+fi
+
+if [ -z "$DOCKER_TEST_HOST" ]; then
+    export DOCKER_HOST="unix://$(cd "$DEST" && pwd)/docker.sock" # "pwd" tricks to make sure $DEST is an absolute path, not a relative one
+    ( set -x; exec \
+                  docker daemon --debug \
+                  --host "$DOCKER_HOST" \
+                  --storage-driver "$DOCKER_GRAPHDRIVER" \
+                  --pidfile "$DEST/docker.pid" \
+                  --userland-proxy="$DOCKER_USERLANDPROXY" \
+                  $storage_params \
+      &> "$DEST/docker.log"
+    ) &
+    # make sure that if the script exits unexpectedly, we stop this daemon we just started
+    trap 'bundle .integration-daemon-stop' EXIT
+else
+    export DOCKER_HOST="$DOCKER_TEST_HOST"
+fi
+
+echo docker host $DOCKER_HOST
+echo docker test host $DOCKER_TEST_HOST
+cat $DEST/docker.log
+
+# give it a second to come up so it's "ready"
+tries=5
+while ! docker version &> /dev/null; do
+    (( tries-- ))
+    if [ $tries -le 0 ]; then
+        if [ -z "$DOCKER_HOST" ]; then
+            echo >&2 "error: daemon failed to start"
+            echo >&2 "  check $DEST/docker.log for details"
+        else
+            echo >&2 "error: daemon at $DOCKER_HOST fails to 'docker version':"
+            docker version >&2 || true
+        fi
+        false
+    fi
+    sleep 2
+done
+
+docker version

--- a/hack/.integration-daemon-stop
+++ b/hack/.integration-daemon-stop
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+trap - EXIT # reset EXIT trap applied in .integration-daemon-start
+
+for pidFile in $(find "$DEST" -name docker.pid); do
+	pid=$(set -x; cat "$pidFile")
+	( set -x; kill "$pid" )
+	if ! wait "$pid"; then
+		echo >&2 "warning: PID $pid from $pidFile had a nonzero exit code"
+	fi
+done

--- a/hack/dind
+++ b/hack/dind
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# DinD: a wrapper script which allows docker to be run inside a docker container.
+# Original version by Jerome Petazzoni <jerome@docker.com>
+# See the blog post: https://blog.docker.com/2013/09/docker-can-now-run-within-docker/
+#
+# This script should be executed inside a docker container in privilieged mode
+# ('docker run --privileged', introduced in docker 0.6).
+
+# Usage: dind CMD [ARG...]
+
+# apparmor sucks and Docker needs to know that it's in a container (c) @tianon
+export container=docker
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+	mount -t securityfs none /sys/kernel/security || {
+		echo >&2 'Could not mount /sys/kernel/security.'
+		echo >&2 'AppArmor detection and --privileged mode might break.'
+	}
+fi
+
+# Mount /tmp (conditionally)
+if ! mountpoint -q /tmp; then
+	mount -t tmpfs none /tmp
+fi
+
+if [ $# -gt 0 ]; then
+	exec "$@"
+fi
+
+echo >&2 'ERROR: No command specified.'
+echo >&2 'You probably want to run hack/make.sh, or maybe a shell?'

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -39,10 +39,6 @@ bundle() {
     source "hack/$bundle" "$@"
 }
 
-docker version
-
-echo $DOCKER_API_VERSION
-
 if [ $# -lt 1 ]; then
     bundles=(${DEFAULT_BUNDLES[@]})
 else

--- a/hack/test-integration
+++ b/hack/test-integration
@@ -1,19 +1,33 @@
 #!/bin/bash
 set -e
 
-bundle_test_integration() {
-	TESTFLAGS="$TESTFLAGS"
-	go_test_dir ./integration/docker
-        go_test_dir ./integration/docker/check
-        go_test_dir ./integration/docker/testing
-        go_test_dir ./integration/compose
-        go_test_dir ./integration/compose/check
-        go_test_dir ./integration/compose/testing
-        # hum wonder how to handle that
+run_integration_test() {
+    echo "Running integration test against ${DOCKER_DAEMON_VERSION}"
+    bundle .integration-daemon-start
+    
+    TESTFLAGS="$TESTFLAGS"
+    go_test_dir ./integration/docker
+    go_test_dir ./integration/docker/check
+    go_test_dir ./integration/docker/testing
+    go_test_dir ./integration/compose
+    go_test_dir ./integration/compose/check
+    go_test_dir ./integration/compose/testing
+
+    bundle .integration-daemon-stop
+    echo
 }
 
-# subshell so that we can export PATH without breaking other things
 (
-	export GO15VENDOREXPERIMENT=1
-	bundle_test_integration
+    if test -n "${DAEMON_VERSION}" && test "${DAEMON_VERSION}" != "all"; then
+        if test "${DAEMON_VERSION}" = "default"; then
+            DAEMON_VERSION="${DEFAULT_DOCKER_VERSION}"
+        fi
+        for version in $(echo ${DAEMON_VERSION} | cut -f1); do
+            DOCKER_DAEMON_VERSION="${version}" run_integration_test
+        done
+    else
+        for version in $(echo ${DOCKER_VERSIONS} | cut -f1); do
+            DOCKER_DAEMON_VERSION="${version}" run_integration_test
+        done
+    fi
 ) 2>&1


### PR DESCRIPTION
You can specify against which "supported" daemon you want to be tested
against (test-integration). It happens through the `DAEMON_VERSION`
environment variables.

You can specify one or more value to it ; the only value supported are
those in the Dockefile (`ENV DOCKER_VERSION …`). It will fail if the
version is not found. Thus :

- `DAEMON_VERSION="1.9.1" make test-integration` will run integration
  tests against a 1.9.1 daemon
- `DAEMON_VERSION="1.10.3 1.11.0" make test-integration` will run
   integration tests against a 1.10.3 daemon and a 1.11.0 daemon.
- `DAEMON_VERSION="default" make test-integration` or `make
  test-integration` will run integration tests against the default
  daemon (specified in the the `Dockerfile`)

`DAEMON_VERSION="all"` or empty, it will test against all support daemon
version. On the CI, `DAEMON_VERSION` is empty, thus testing against all
supported version as well.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>